### PR TITLE
Add support for Font Awesome 5

### DIFF
--- a/jekyll-font-awesome-sass.gemspec
+++ b/jekyll-font-awesome-sass.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'jekyll', '>= 2.5', '< 4.0'
-  spec.add_dependency 'font-awesome-sass', '~> 4'
+  spec.add_dependency 'font-awesome-sass', ['>=4', '~> 5']
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
This pull request adds support for [Font Awesome version 5](https://github.com/FortAwesome/font-awesome-sass#breaking-changes). Although Font Awesome itself has undergone a few breaking changes with the release of version 5, the `font-awesome-sass` gem appears to have not. As stated in the README, this change would allow end users to specify either version 4 or 5 in their Gemfiles.

### Changed
* Depend on `font-awesome-sass` version `>= 4`  and `~> 5`.