### PR TITLE
Feature/font awesome 5

### DIFF
--- a/jekyll-font-awesome-sass.gemspec
+++ b/jekyll-font-awesome-sass.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'jekyll', '>= 2.5', '< 4.0'
-  spec.add_dependency 'font-awesome-sass', ['~> 5', '~>4' ]
+  spec.add_dependency 'font-awesome-sass', '>=4'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/jekyll-font-awesome-sass.gemspec
+++ b/jekyll-font-awesome-sass.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'jekyll', '>= 2.5', '< 4.0'
-  spec.add_dependency 'font-awesome-sass', ['~> 5']
+  spec.add_dependency 'font-awesome-sass', ['~> 5', '~>4' ]
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/jekyll-font-awesome-sass.gemspec
+++ b/jekyll-font-awesome-sass.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['andrew morton']
   spec.email         = ['drewish@katherinehouse.com']
 
-  spec.summary       = 'A plugin to add Twitter Bootstrap to your Jekyll site'
+  spec.summary       = 'A plugin to add Font Awesome to your Jekyll site.'
   spec.homepage      = 'https://github.com/drewish/jekyll-font-awesome-sass'
   spec.license       = 'MIT'
 
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'jekyll', '>= 2.5', '< 4.0'
-  spec.add_dependency 'font-awesome-sass', ['>=4', '~> 5']
+  spec.add_dependency 'font-awesome-sass', ['~> 5']
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/jekyll-font-awesome-sass/version.rb
+++ b/lib/jekyll-font-awesome-sass/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module FontAwesomeSass
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end


### PR DESCRIPTION
I have noticed that i can't configure it to use Font Awesome newer than 4.7.0.

The configuration of `spec.add_dependency 'font-awesome-sass'` seems to prevent using version > 5.

Also the summary says "A plugin to add Twitter Bootstrap...". I changed it into Font Awesome.

I set the version to 0.1.1.